### PR TITLE
Update Chinese translation

### DIFF
--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -8,7 +8,7 @@
     "downString2": "暂时不可用。",
     "responseTime": "延时",
     "httpCode": "HTTP 状态码",
-    "incidentId": "Incident ID",
+    "incidentId": "事故编号",
     "machineId": "Roblox Machine ID",
     "responseMessage": "Response Message",
     "errorMessage": "Error Message"

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -6,7 +6,7 @@
     "degradedString2": "的性能降低了。",
     "downString1": "遇到了问题，现停止运行。",
     "downString2": "暂时不可用。",
-    "responseTime": "延时",
+    "responseTime": "延迟",
     "httpCode": "HTTP 状态码",
     "incidentId": "事故编号",
     "machineId": "计算机编号",

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -5,7 +5,13 @@
     "degradedString1": "遇到了一些技术性问题。",
     "degradedString2": "的性能降低了。",
     "downString1": "遇到了问题，现停止运行。",
-    "downString2": "暂时不可用。"
+    "downString2": "暂时不可用。",
+    "responseTime": "延时",
+    "httpCode": "Status Code",
+    "incidentId": "Incident ID",
+    "machineId": "Roblox Machine ID",
+    "responseMessage": "Response Message",
+    "errorMessage": "Error Message"
   },
   "fastFlagStrings": {
     "addedString": "已被添加！",

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -7,7 +7,7 @@
     "downString1": "遇到了问题，现停止运行。",
     "downString2": "暂时不可用。",
     "responseTime": "延时",
-    "httpCode": "Status Code",
+    "httpCode": "状态码",
     "incidentId": "Incident ID",
     "machineId": "Roblox Machine ID",
     "responseMessage": "Response Message",

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -11,7 +11,7 @@
     "incidentId": "事故编号",
     "machineId": "计算机编号",
     "responseMessage": "返回信息",
-    "errorMessage": "Error Message"
+    "errorMessage": "错误码"
   },
   "fastFlagStrings": {
     "addedString": "已被添加！",

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -17,8 +17,8 @@
     "addedString": "已被添加！",
     "modifiedString": "已被更改！",
     "deletedString": "已被删除。",
-    "oldValue": "更改之前的值:",
-    "newValue": "更改之后的值:",
+    "oldValue": "旧值:",
+    "newValue": "新值:",
     "value": "值:",
     "type": "标志类型:"
   },

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -17,10 +17,10 @@
     "addedString": "已被添加！",
     "modifiedString": "已被更改！",
     "deletedString": "已被删除。",
-    "oldValue": "更改之前的值:",
-    "newValue": "更改之后的值:",
-    "value": "值:",
-    "type": "快速标志种类:"
+    "oldValue": "更改之前的数值:",
+    "newValue": "更改之后的数值:",
+    "value": "数值:",
+    "type": "标志类型:"
   },
   "metaStrings": {
     "name": "Chinese"

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -9,7 +9,7 @@
     "responseTime": "延迟",
     "httpCode": "HTTP 状态码",
     "incidentId": "事故编号",
-    "machineId": "计算机编号",
+    "machineId": "服务器编号",
     "responseMessage": "返回信息",
     "errorMessage": "错误码"
   },

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -7,7 +7,7 @@
     "downString1": "遇到了问题，现停止运行。",
     "downString2": "暂时不可用。",
     "responseTime": "延时",
-    "httpCode": "状态码",
+    "httpCode": "HTTP 状态码",
     "incidentId": "Incident ID",
     "machineId": "Roblox Machine ID",
     "responseMessage": "Response Message",

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -17,9 +17,9 @@
     "addedString": "已被添加！",
     "modifiedString": "已被更改！",
     "deletedString": "已被删除。",
-    "oldValue": "更改之前的数值:",
-    "newValue": "更改之后的数值:",
-    "value": "数值:",
+    "oldValue": "更改之前的值:",
+    "newValue": "更改之后的值:",
+    "value": "值:",
     "type": "标志类型:"
   },
   "metaStrings": {

--- a/languages/ZH.json
+++ b/languages/ZH.json
@@ -9,8 +9,8 @@
     "responseTime": "延时",
     "httpCode": "HTTP 状态码",
     "incidentId": "事故编号",
-    "machineId": "Roblox Machine ID",
-    "responseMessage": "Response Message",
+    "machineId": "计算机编号",
+    "responseMessage": "返回信息",
     "errorMessage": "Error Message"
   },
   "fastFlagStrings": {


### PR DESCRIPTION
- Added translation for `responseTime`, `httpCode`, `incidientId`, `responseMessage`, `errorMessage`
- Rectified translation for `type`, `value`, `newValue`, `oldValue`
    * `种类` is a weird way to describe data types, we usually use `类型` instead.
    * ~~`值` can describe values, but `数值` is usually better~~ – **Reverted as `数值` is more used for numbers**
    * Shorted translation for `oldValue` and `newValue`